### PR TITLE
Remove unused variable, fix high version gcc compile error.

### DIFF
--- a/src/ngx_http_tfs_rc_server_info.c
+++ b/src/ngx_http_tfs_rc_server_info.c
@@ -325,9 +325,7 @@ void
 ngx_http_tfs_dump_rc_info(ngx_http_tfs_rcs_info_t *rc_info, ngx_log_t *log)
 {
     uint32_t                            i, j, k;
-    ngx_http_tfs_group_info_t          *group_info;
     ngx_http_tfs_logical_cluster_t     *logical_clusters;
-    ngx_http_tfs_physical_cluster_t    *physical_clusters;
     ngx_http_tfs_cluster_group_info_t  *unlink_cluster_groups;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0, "=========dump rc info for appkey: %V =========",
@@ -340,7 +338,6 @@ ngx_http_tfs_dump_rc_info(ngx_http_tfs_rcs_info_t *rc_info, ngx_log_t *log)
                        logical_clusters[i].need_duplicate);
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0, "rw_cluster_count: %uD",
                        logical_clusters[i].rw_cluster_count);
-        physical_clusters = logical_clusters[i].rw_clusters;
         for (j = 0; j < logical_clusters[i].rw_cluster_count; j++) {
             ngx_log_debug4(NGX_LOG_DEBUG_HTTP, log, 0,
                            "cluster_stat: %uD, access_type: %uD, cluster_id: %V, ns_vip: %V",
@@ -358,7 +355,6 @@ ngx_http_tfs_dump_rc_info(ngx_http_tfs_rcs_info_t *rc_info, ngx_log_t *log)
                        unlink_cluster_groups[j].cluster_id,
                        unlink_cluster_groups[j].info_count,
                        unlink_cluster_groups[j].group_count);
-        group_info = unlink_cluster_groups[j].group_info;
         for (k = 0; k < unlink_cluster_groups[j].info_count; k++) {
             ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0, "group_seq: %D, ns_vip: %V",
                            group_info[k].group_seq,

--- a/src/ngx_tfs_common.c
+++ b/src/ngx_tfs_common.c
@@ -894,16 +894,14 @@ ngx_http_tfs_get_request_time(ngx_http_tfs_t *t)
     ngx_msec_int_t             ms;
     struct timeval             tv;
     ngx_http_request_t        *r;
-    ngx_http_core_loc_conf_t  *clcf;
 
     r = t->data;
-    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 #if defined(tengine_version) && tengine_version>=1002003
     if (clcf->request_time_cache) {
         ngx_time_t *tp = ngx_timeofday();
         ms = (ngx_msec_int_t)
                  ((tp->sec - r->start_sec) * 1000 + (tp->msec - r->start_msec));
-    } else 
+    } else
 #endif
     {
         ngx_gettimeofday(&tv);


### PR DESCRIPTION
Env:

```
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/4.8.5/lto-wrapper
Target: x86_64-redhat-linux
Configured with: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-bootstrap --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-linker-hash-style=gnu --enable-languages=c,c++,objc,obj-c++,java,fortran,ada,go,lto --enable-plugin --enable-initfini-array --disable-libgcj --with-isl=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/isl-install --with-cloog=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/cloog-install --enable-gnu-indirect-function --with-tune=generic --with-arch_32=x86-64 --build=x86_64-redhat-linux
Thread model: posix
gcc version 4.8.5 20150623 (Red Hat 4.8.5-4) (GCC)
```

Fix error:

```
/usr/local/src/nginx-tfs/src/ngx_tfs_common.c: In function ‘ngx_http_tfs_get_request_time’:
/usr/local/src/nginx-tfs/src/ngx_tfs_common.c:897:32: error: variable ‘clcf’ set but not used [-Werror=unused-but-set-variable]
     ngx_http_core_loc_conf_t  *clcf;
                                ^
cc1: all warnings being treated as errors
make[1]: *** [objs/addon/src/ngx_tfs_common.o] Error 1
make[1]: Leaving directory `/usr/local/src/nginx-1.8.1'
make: *** [build] Error 2

/usr/local/src/nginx-tfs/src/ngx_http_tfs_rc_server_info.c: In function ‘ngx_http_tfs_dump_rc_info’:
/usr/local/src/nginx-tfs/src/ngx_http_tfs_rc_server_info.c:341:9: error: ‘physical_clusters’ undeclared (first use in this function)
         physical_clusters = logical_clusters[i].rw_clusters;
         ^
/usr/local/src/nginx-tfs/src/ngx_http_tfs_rc_server_info.c:341:9: note: each undeclared identifier is reported only once for each function it appears in
/usr/local/src/nginx-tfs/src/ngx_http_tfs_rc_server_info.c:359:9: error: ‘group_info’ undeclared (first use in this function)
         group_info = unlink_cluster_groups[j].group_info;
```
